### PR TITLE
List the active PQRS for the admin and the functionary

### DIFF
--- a/src/main/java/co/edu/itp/svu/repository/PqrsRepository.java
+++ b/src/main/java/co/edu/itp/svu/repository/PqrsRepository.java
@@ -1,7 +1,13 @@
 package co.edu.itp.svu.repository;
 
 import co.edu.itp.svu.domain.Pqrs;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Date;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,6 +16,20 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface PqrsRepository extends MongoRepository<Pqrs, String> {
-    List<Pqrs> findByOficinaResponder_Id(String oficinaId); // Método para encontrar PQRS por oficinaId
-    List<Pqrs> findByEstado(String estado);
+    List<Pqrs> findByOficinaResponder_Id(String oficinaId);
+    List<Pqrs> findByEstadoAndFechaCreacionLessThanEqual(String estado, LocalDate fecha, Pageable pageable);
+    Page<Pqrs> findAllByEstadoNotAndFechaCreacionLessThanEqual(String estado, LocalDate fecha, Pageable pageable);
+    Page<Pqrs> findAllByEstadoAndFechaCreacionLessThanEqual(String estado, LocalDate fecha, Pageable pageable);
+    Page<Pqrs> findByEstadoNotAndOficinaResponder_IdAndFechaCreacionLessThanEqual(
+        String estado,
+        String oficinaId,
+        LocalDate fecha,
+        Pageable pageable
+    );
+    Page<Pqrs> findByEstadoAndOficinaResponder_IdAndFechaCreacionLessThanEqual(
+        String estado,
+        String oficinaId,
+        LocalDate fecha,
+        Pageable pageable
+    );
 }

--- a/src/main/java/co/edu/itp/svu/repository/PqrsRepository.java
+++ b/src/main/java/co/edu/itp/svu/repository/PqrsRepository.java
@@ -17,19 +17,19 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PqrsRepository extends MongoRepository<Pqrs, String> {
     List<Pqrs> findByOficinaResponder_Id(String oficinaId);
-    List<Pqrs> findByEstadoAndFechaCreacionLessThanEqual(String estado, LocalDate fecha, Pageable pageable);
-    Page<Pqrs> findAllByEstadoNotAndFechaCreacionLessThanEqual(String estado, LocalDate fecha, Pageable pageable);
-    Page<Pqrs> findAllByEstadoAndFechaCreacionLessThanEqual(String estado, LocalDate fecha, Pageable pageable);
+    List<Pqrs> findByEstadoAndFechaCreacionLessThanEqual(String state, LocalDate date, Pageable pageable);
+    Page<Pqrs> findAllByEstadoNotAndFechaCreacionLessThanEqual(String state, LocalDate date, Pageable pageable);
+    Page<Pqrs> findAllByEstadoAndFechaCreacionLessThanEqual(String state, LocalDate date, Pageable pageable);
     Page<Pqrs> findByEstadoNotAndOficinaResponder_IdAndFechaCreacionLessThanEqual(
-        String estado,
-        String oficinaId,
-        LocalDate fecha,
+        String state,
+        String officeId,
+        LocalDate date,
         Pageable pageable
     );
     Page<Pqrs> findByEstadoAndOficinaResponder_IdAndFechaCreacionLessThanEqual(
-        String estado,
-        String oficinaId,
-        LocalDate fecha,
+        String state,
+        String officeId,
+        LocalDate date,
         Pageable pageable
     );
 }

--- a/src/main/java/co/edu/itp/svu/repository/PqrsRepository.java
+++ b/src/main/java/co/edu/itp/svu/repository/PqrsRepository.java
@@ -1,11 +1,8 @@
 package co.edu.itp.svu.repository;
 
 import co.edu.itp.svu.domain.Pqrs;
-import java.time.Instant;
 import java.time.LocalDate;
-import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;

--- a/src/main/java/co/edu/itp/svu/web/rest/PqrsResource.java
+++ b/src/main/java/co/edu/itp/svu/web/rest/PqrsResource.java
@@ -4,21 +4,30 @@ import co.edu.itp.svu.repository.PqrsRepository;
 import co.edu.itp.svu.service.PqrsService;
 import co.edu.itp.svu.service.dto.PqrsDTO;
 import co.edu.itp.svu.web.rest.errors.BadRequestAlertException;
+
 import jakarta.validation.constraints.NotNull;
+
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
 import tech.jhipster.web.util.HeaderUtil;
 import tech.jhipster.web.util.PaginationUtil;
 import tech.jhipster.web.util.ResponseUtil;
@@ -86,9 +95,19 @@ public class PqrsResource {
      * @return the {@link ResponseEntity} with status {@code 200 (OK)} and the list of pqrs in body.
      */
     @GetMapping("")
-    public ResponseEntity<List<PqrsDTO>> getAllPqrs(@org.springdoc.core.annotations.ParameterObject Pageable pageable) {
+    public ResponseEntity<List<PqrsDTO>> getAllPqrs(
+        @RequestParam(defaultValue = "closed", required = false) String state,
+        @RequestParam(required = false) String idOffice,
+        @RequestParam(name = "date", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date,
+        @org.springdoc.core.annotations.ParameterObject Pageable pageable
+    ) {
         LOG.debug("REST request to get a page of Pqrs");
-        Page<PqrsDTO> page = pqrsService.findAllOficina(pageable);
+        if (date == null) {
+            date = LocalDate.now();
+        }
+        
+        LocalDate fechaLimite = date.plusDays(1);
+        Page<PqrsDTO> page = pqrsService.findAll(state, idOffice, fechaLimite, pageable);
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(ServletUriComponentsBuilder.fromCurrentRequest(), page);
         return ResponseEntity.ok().headers(headers).body(page.getContent());
     }

--- a/src/main/java/co/edu/itp/svu/web/rest/PqrsResource.java
+++ b/src/main/java/co/edu/itp/svu/web/rest/PqrsResource.java
@@ -106,8 +106,8 @@ public class PqrsResource {
             date = LocalDate.now();
         }
         
-        LocalDate fechaLimite = date.plusDays(1);
-        Page<PqrsDTO> page = pqrsService.findAll(state, idOffice, fechaLimite, pageable);
+        LocalDate deadline = date.plusDays(1);
+        Page<PqrsDTO> page = pqrsService.findAll(state, idOffice, deadline, pageable);
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(ServletUriComponentsBuilder.fromCurrentRequest(), page);
         return ResponseEntity.ok().headers(headers).body(page.getContent());
     }

--- a/src/main/java/co/edu/itp/svu/web/rest/PqrsResource.java
+++ b/src/main/java/co/edu/itp/svu/web/rest/PqrsResource.java
@@ -4,19 +4,13 @@ import co.edu.itp.svu.repository.PqrsRepository;
 import co.edu.itp.svu.service.PqrsService;
 import co.edu.itp.svu.service.dto.PqrsDTO;
 import co.edu.itp.svu.web.rest.errors.BadRequestAlertException;
-
 import jakarta.validation.constraints.NotNull;
-
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.time.Instant;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -27,7 +21,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
-
 import tech.jhipster.web.util.HeaderUtil;
 import tech.jhipster.web.util.PaginationUtil;
 import tech.jhipster.web.util.ResponseUtil;
@@ -105,7 +98,6 @@ public class PqrsResource {
         if (date == null) {
             date = LocalDate.now();
         }
-        
         LocalDate deadline = date.plusDays(1);
         Page<PqrsDTO> page = pqrsService.findAll(state, idOffice, deadline, pageable);
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(ServletUriComponentsBuilder.fromCurrentRequest(), page);


### PR DESCRIPTION
### Description
This change request is intended to create methods to filter the **PQRS**, these can be filtered fields (`estado`, `fechaCreacion `and `oficinaResponsable`), it was also configured to show the **PQRS** that are closed. 
was also configured so that when a pqrs is created some fields have default values; `estado`= "pendiente", `fechaCreacion `will insert the field in which it was created, and `oficinaResponsable`= "Oficina General".

### Fixes #14

### Screenshots
<img width="905" alt="filtros" src="https://github.com/user-attachments/assets/3e7b6fc8-ee11-4313-803e-f833239add36" />
