### PR TITLE
Add the resolve button to pqrs detail in functionary view

### DIFF
--- a/src/main/webapp/app/constants.ts
+++ b/src/main/webapp/app/constants.ts
@@ -8,4 +8,5 @@ export enum StatesPqrs {
   InProcess = 'EN PROCESO',
   Resolved = 'RESUELTA',
   Closed = 'CERRADA',
+  Rejected = 'RECHAZADA',
 }

--- a/src/main/webapp/app/entities/pqrs/pqrs-details.component.ts
+++ b/src/main/webapp/app/entities/pqrs/pqrs-details.component.ts
@@ -1,7 +1,8 @@
-import { type Ref, defineComponent, inject, ref } from 'vue';
+import { type Ref, defineComponent, inject, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
 
+import { StatesPqrs } from '../../constants';
 import PqrsService from './pqrs.service';
 import useDataUtils from '@/shared/data/data-utils.service';
 import { useDateFormat } from '@/shared/composables';
@@ -12,9 +13,11 @@ export default defineComponent({
   compatConfig: { MODE: 3 },
   name: 'PqrsDetails',
   setup() {
+    const { t } = useI18n();
     const dateFormat = useDateFormat();
     const pqrsService = inject('pqrsService', () => new PqrsService());
     const alertService = inject('alertService', () => useAlertService(), true);
+    const { formatDateLong } = useDateFormat();
 
     const dataUtils = useDataUtils();
 
@@ -33,19 +36,59 @@ export default defineComponent({
       }
     };
 
-    if (route.params?.pqrsId) {
-      retrievePqrs(route.params.pqrsId);
-    }
+    const toggleEstadoPqrs = async () => {
+      if (pqrs.value && pqrs.value.id) {
+        let newState: string;
+        let successMessageKey: string;
+
+        if (pqrs.value.estado === StatesPqrs.Resolved) {
+          newState = StatesPqrs.InProcess;
+          successMessageKey = 'ventanillaUnicaApp.pqrs.messages.inProgresSuccess';
+        } else {
+          newState = StatesPqrs.Resolved;
+          successMessageKey = 'ventanillaUnicaApp.pqrs.messages.resolvedSuccess';
+        }
+
+        const pqrsToUpdate: IPqrs = {
+          ...pqrs.value,
+          estado: newState,
+        };
+
+        try {
+          const result = await pqrsService().update(pqrsToUpdate);
+          pqrs.value = result;
+          alertService.showSuccess(t(successMessageKey));
+        } catch (error) {
+          console.error('Error al cambiar estado de PQRS:', error);
+          const errorMessageKey = 'ventanillaUnicaApp.pqrs.messages.resolvedSuccess';
+          if (error.response) {
+            alertService.showHttpError(error.response);
+          } else {
+            alertService.showError(t(resolvedError));
+          }
+        }
+      }
+    };
+
+    onMounted(async () => {
+      const pqrsId = route.params.pqrsId;
+      if (pqrsId) {
+        await retrievePqrs(pqrsId);
+      }
+    });
 
     return {
       ...dateFormat,
       alertService,
       pqrs,
-
+      StatesPqrs,
       ...dataUtils,
 
       previousState,
       t$: useI18n().t,
+      t,
+      formatDateLong,
+      toggleEstadoPqrs,
     };
   },
 });

--- a/src/main/webapp/app/entities/pqrs/pqrs-details.vue
+++ b/src/main/webapp/app/entities/pqrs/pqrs-details.vue
@@ -42,7 +42,7 @@
           <dd>
             <div v-if="pqrs.oficinaResponder">
               <router-link :to="{ name: 'OficinaView', params: { oficinaId: pqrs.oficinaResponder.id } }">{{
-                pqrs.oficinaResponder.id
+                pqrs.oficinaResponder.nombre || pqrs.oficinaResponder.id
               }}</router-link>
             </div>
           </dd>
@@ -56,6 +56,20 @@
             <font-awesome-icon icon="pencil-alt"></font-awesome-icon>&nbsp;<span v-text="t$('entity.action.edit')"></span>
           </button>
         </router-link>
+
+        <button
+          v-if="pqrs.id"
+          @click="toggleEstadoPqrs()"
+          :class="['btn', pqrs.estado === StatesPqrs.Resolved ? 'btn-warning' : 'btn-success', 'ms-2']"
+          data-cy="toggleStatusButton"
+        >
+          <font-awesome-icon :icon="pqrs.estado === StatesPqrs.Resolved ? 'undo-alt' : 'check-circle'"></font-awesome-icon>
+          <span v-if="pqrs.estado === StatesPqrs.Resolved" v-text="t('ventanillaUnicaApp.pqrs.action.inProgres')"></span>
+          <span v-else v-text="t('ventanillaUnicaApp.pqrs.action.resolve')"></span>
+        </button>
+        <div v-else>
+          <p v-text="t('global.messages.info.loading')"></p>
+        </div>
       </div>
     </div>
   </div>

--- a/src/main/webapp/i18n/en/pqrs.json
+++ b/src/main/webapp/i18n/en/pqrs.json
@@ -24,7 +24,17 @@
       "fechaLimiteRespuesta": "Deadline Response",
       "estado": "Select a State",
       "archivosAdjuntos": "Attachments",
-      "oficinaResponder": "Responsible Office"
+      "oficinaResponder": "Responsible Office",
+      "action": {
+        "resolve": "Mark as Solved",
+        "inProgres": "In Process"
+      },
+      "messages": {
+        "resolvedSuccess": "PQRS marked as successfully resolved.",
+        "resolvedError": "Error when marking the PQRS as resolved.",
+        "notFound": "PQRS not found.",
+        "inProgresSuccess": "PQRS marked as In Process successfully."
+      }
     }
   }
 }

--- a/src/main/webapp/i18n/es/pqrs.json
+++ b/src/main/webapp/i18n/es/pqrs.json
@@ -25,7 +25,17 @@
       "fechaLimiteRespuesta": "Fecha Limite Respuesta",
       "estado": "Seleciona un Estado",
       "archivosAdjuntos": "Archivos Adjuntos",
-      "oficinaResponder": "Oficina Responsable"
+      "oficinaResponder": "Oficina Responsable",
+      "action": {
+        "resolve": "Marcar como Resuelta",
+        "inProgres": "En Proceso"
+      },
+      "messages": {
+        "resolvedSuccess": "Estado de PQRS cambio a \"RESUELTA\".",
+        "resolvedError": "Error al marcar la PQRS como resuelta.",
+        "notFound": "PQRS no encontrada.",
+        "inProgresSuccess": "Estado de PQRS cambio a \"EN PROCESO\"."
+      }
     }
   }
 }


### PR DESCRIPTION
### Description
A button has been added that allows the employee to mark a **PQRS** as **RESOLVED**, but also allows the fuctionary to return to the **IN PROCESS** status if something is missing to complete the response.

### Fixes #15 

### Screenshots
<img width="930" alt="resuelta" src="https://github.com/user-attachments/assets/4c48e495-34a5-46d1-9d29-51a2436f4160" />
<img width="953" alt="enProceso" src="https://github.com/user-attachments/assets/4c92ad36-d8ec-49d8-b5ec-1e8dd4f2d5e9" />
