### PR TITLE
Handle the notifications for CREATE and UPDATE events in a PQRS

### DIFF
--- a/src/main/java/co/edu/itp/svu/config/SecurityConfiguration.java
+++ b/src/main/java/co/edu/itp/svu/config/SecurityConfiguration.java
@@ -74,7 +74,7 @@ public class SecurityConfiguration {
                     .requestMatchers(mvc.pattern("/api/oficina/**")).hasAnyAuthority(AuthoritiesConstants.ADMIN)
                     .requestMatchers(mvc.pattern("/api/archivo-adjunto/**")).hasAnyAuthority(AuthoritiesConstants.ADMIN)
                     .requestMatchers(mvc.pattern("/api/informe-pqrs/**")).hasAnyAuthority(AuthoritiesConstants.ADMIN)
-                    .requestMatchers(mvc.pattern("/api/sse-notifications/subscribe")).hasAnyAuthority(AuthoritiesConstants.ADMIN, AuthoritiesConstants.FUNCTIONARY)
+                    .requestMatchers(mvc.pattern("/api/sse-notifications/subscribe")).hasAnyAuthority(AuthoritiesConstants.ADMIN, AuthoritiesConstants.FUNCTIONARY, AuthoritiesConstants.FRONT_DESK_CS)
                     .requestMatchers(mvc.pattern("/api/notifications/**")).permitAll()
                     .requestMatchers(mvc.pattern("/api/oficinas/oficinasUserLogin/*")).permitAll()
                     .requestMatchers(mvc.pattern("/api/admin/**")).hasAuthority(AuthoritiesConstants.ADMIN)

--- a/src/main/java/co/edu/itp/svu/repository/UserRepository.java
+++ b/src/main/java/co/edu/itp/svu/repository/UserRepository.java
@@ -28,4 +28,6 @@ public interface UserRepository extends MongoRepository<User, String> {
     Optional<User> findOneByLogin(String login);
 
     Page<User> findAllByIdNotNullAndActivatedIsTrue(Pageable pageable);
+
+    User findByAuthoritiesName(String authority);
 }

--- a/src/main/java/co/edu/itp/svu/scheduler/PqrsScheduler.java
+++ b/src/main/java/co/edu/itp/svu/scheduler/PqrsScheduler.java
@@ -1,19 +1,13 @@
 package co.edu.itp.svu.scheduler;
 
-import co.edu.itp.svu.domain.Notificacion;
 import co.edu.itp.svu.domain.Pqrs;
 import co.edu.itp.svu.domain.User;
 import co.edu.itp.svu.domain.enumeration.PqrsStatus;
-import co.edu.itp.svu.repository.NotificacionRepository;
 import co.edu.itp.svu.repository.PqrsRepository;
-import co.edu.itp.svu.repository.UserRepository;
-import co.edu.itp.svu.service.SseNotificationService;
-import co.edu.itp.svu.service.mapper.PqrsMapper;
+import co.edu.itp.svu.service.notification.PqrsNotificationService;
 import java.time.Instant;
-import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -25,19 +19,11 @@ public class PqrsScheduler {
     private static final Logger LOG = LoggerFactory.getLogger(PqrsScheduler.class);
 
     private final PqrsRepository pqrsRepository;
-    private final SseNotificationService sseNotificationService;
-    private final NotificacionRepository notificationRepository;
+    private final PqrsNotificationService pqrsNotificationService;
 
-    public PqrsScheduler(
-        PqrsRepository pqrsRepository,
-        SseNotificationService sseNotificationService,
-        PqrsMapper pqrsMapper,
-        UserRepository userRepository,
-        NotificacionRepository notificationRepository
-    ) {
+    public PqrsScheduler(PqrsRepository pqrsRepository, PqrsNotificationService pqrsNotificationService) {
         this.pqrsRepository = pqrsRepository;
-        this.sseNotificationService = sseNotificationService;
-        this.notificationRepository = notificationRepository;
+        this.pqrsNotificationService = pqrsNotificationService;
     }
 
     @Scheduled(cron = "0 0 9 * * ?", zone = "America/Bogota")
@@ -65,67 +51,16 @@ public class PqrsScheduler {
                 User responsibleUser = pqrs.getOficinaResponder().getResponsable();
 
                 if (responsibleUser != null) {
-                    createPersistentNotification(responsibleUser, pqrs);
-                    sendPqrsNotification(responsibleUser.getLogin(), pqrs);
+                    pqrsNotificationService.sendPqrsNotification(
+                        pqrs,
+                        PqrsNotificationService.PqrsNotificationType.PQRS_DUE_DATE_REMINDER,
+                        responsibleUser
+                    );
                 }
             } else {
                 LOG.warn("PQRS with id {} has no OficinaResponder, cannot determine responsible user.", pqrs.getId());
             }
         }
         LOG.info("PQRS due date check finished.");
-    }
-
-    private void sendPqrsNotification(String userLogin, Pqrs pqrs) {
-        String message = String.format(
-            "PQRS '%s' (ID: %s) is due on %s.",
-            pqrs.getTitulo(),
-            pqrs.getId(),
-            pqrs.getFechaLimiteRespuesta().toString()
-        );
-
-        var notificationData = Map.of(
-            "id",
-            pqrs.getId(),
-            "type",
-            "PQRS_DUE_DATE_REMINDER",
-            "creationDate",
-            LocalDate.now(),
-            "message",
-            message,
-            "read",
-            false,
-            "userLogin",
-            userLogin,
-            "pqrsId",
-            pqrs.getId(),
-            "title",
-            pqrs.getTitulo(),
-            "pqrsResponseDueDate",
-            pqrs.getFechaLimiteRespuesta(),
-            "isSse",
-            true
-        );
-
-        sseNotificationService.sendNotificationToUser(userLogin, "PQRS_DUE_DATE_REMINDER", notificationData);
-
-        LOG.info("Sent due date reminder for PQRS id {} to user {}", pqrs.getId(), userLogin);
-    }
-
-    private void createPersistentNotification(User responsibleUser, Pqrs pqrs) {
-        String message = String.format(
-            "PQRS '%s' (ID: %s) is due on %s.",
-            pqrs.getTitulo(),
-            pqrs.getId(),
-            pqrs.getFechaLimiteRespuesta().toString()
-        );
-
-        Notificacion notification = new Notificacion();
-        notification.setFecha(Instant.now());
-        notification.setLeido(false);
-        notification.setTipo("PQRS_DUE_DATE_REMINDER");
-        notification.setRecipient(responsibleUser);
-        notification.setMensaje(message);
-
-        notificationRepository.save(notification);
     }
 }

--- a/src/main/java/co/edu/itp/svu/service/notification/PqrsNotificationService.java
+++ b/src/main/java/co/edu/itp/svu/service/notification/PqrsNotificationService.java
@@ -1,0 +1,195 @@
+package co.edu.itp.svu.service.notification;
+
+import co.edu.itp.svu.domain.Notificacion;
+import co.edu.itp.svu.domain.Pqrs;
+import co.edu.itp.svu.domain.User;
+import co.edu.itp.svu.repository.NotificacionRepository;
+import co.edu.itp.svu.repository.UserRepository;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PqrsNotificationService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PqrsNotificationService.class);
+
+    private final NotificacionRepository notificacionRepository;
+    private final UserRepository userRepository;
+    private final SseNotificationService sseNotificationService;
+
+    public PqrsNotificationService(
+        NotificacionRepository notificacionRepository,
+        UserRepository userRepository,
+        SseNotificationService sseNotificationService
+    ) {
+        this.notificacionRepository = notificacionRepository;
+        this.userRepository = userRepository;
+        this.sseNotificationService = sseNotificationService;
+    }
+
+    public enum PqrsNotificationType {
+        PQRS_CREATED("PQRS '%s' (ID: %s) was CREATED", "PQRS_CREATED") {
+            @Override
+            public String getFormattedMessage(Pqrs pqrs, Object... additionalArgs) {
+                return String.format(this.messageTemplate, pqrs.getTitulo(), pqrs.getId());
+            }
+
+            @Override
+            public Map<String, Object> buildSseData(Pqrs pqrs, User recipient, String message, String persistentNotificationId) {
+                return Map.of(
+                    "id",
+                    UUID.randomUUID().toString(),
+                    "type",
+                    getEventKey(),
+                    "creationDate",
+                    LocalDate.now().toString(),
+                    "message",
+                    message,
+                    "read",
+                    false,
+                    "userLogin",
+                    recipient.getLogin(),
+                    "pqrsId",
+                    pqrs.getId(),
+                    "pqrsTitle",
+                    pqrs.getTitulo(),
+                    "isSse",
+                    true,
+                    "persistentNotificationId",
+                    persistentNotificationId
+                );
+            }
+        },
+        PQRS_RESOLVED("PQRS '%s' (ID: %s) status was updated to RESOLVED", "PQRS_STATE_UPDATE") {
+            @Override
+            public String getFormattedMessage(Pqrs pqrs, Object... additionalArgs) {
+                return String.format(this.messageTemplate, pqrs.getTitulo(), pqrs.getId());
+            }
+
+            @Override
+            public Map<String, Object> buildSseData(Pqrs pqrs, User recipient, String message, String persistentNotificationId) {
+                return Map.of(
+                    "id",
+                    UUID.randomUUID().toString(),
+                    "type",
+                    getEventKey(),
+                    "creationDate",
+                    LocalDate.now().toString(),
+                    "message",
+                    message,
+                    "read",
+                    false,
+                    "userLogin",
+                    recipient.getLogin(),
+                    "pqrsId",
+                    pqrs.getId(),
+                    "pqrsTitle",
+                    pqrs.getTitulo(),
+                    "isSse",
+                    true,
+                    "persistentNotificationId",
+                    persistentNotificationId
+                );
+            }
+        },
+        PQRS_DUE_DATE_REMINDER("PQRS '%s' (ID: %s) is due on %s.", "PQRS_DUE_DATE_REMINDER") {
+            @Override
+            public String getFormattedMessage(Pqrs pqrs, Object... additionalArgs) {
+                return String.format(this.messageTemplate, pqrs.getTitulo(), pqrs.getId(), pqrs.getFechaLimiteRespuesta().toString());
+            }
+
+            @Override
+            public Map<String, Object> buildSseData(Pqrs pqrs, User recipient, String message, String persistentNotificationId) {
+                Map<String, Object> data = new HashMap<>();
+                data.put("id", UUID.randomUUID().toString());
+                data.put("type", getEventKey());
+                data.put("creationDate", LocalDate.now().toString());
+                data.put("message", message);
+                data.put("read", false);
+                data.put("userLogin", recipient.getLogin());
+                data.put("pqrsId", pqrs.getId());
+                data.put("pqrsTitle", pqrs.getTitulo());
+                data.put("isSse", true);
+                data.put("persistentNotificationId", persistentNotificationId);
+
+                if (pqrs.getFechaLimiteRespuesta() != null) {
+                    data.put("pqrsResponseDueDate", pqrs.getFechaLimiteRespuesta());
+                }
+                return data;
+            }
+        };
+
+        protected final String messageTemplate;
+        protected final String eventKey;
+
+        PqrsNotificationType(String messageTemplate, String eventKey) {
+            this.messageTemplate = messageTemplate;
+            this.eventKey = eventKey;
+        }
+
+        public String getEventKey() {
+            return eventKey;
+        }
+
+        /**
+         * Gets the formatted message for this notification type.
+         *
+         * @param pqrs           The Pqrs entity.
+         * @param additionalArgs Optional additional arguments for formatting, if the
+         *                       template needs them beyond pqrs fields.
+         * @return The formatted message string.
+         */
+        public abstract String getFormattedMessage(Pqrs pqrs, Object... additionalArgs);
+
+        /**
+         * Builds the data map for an SSE notification.
+         *
+         * @param pqrs                     The Pqrs entity.
+         * @param recipient                The recipient user.
+         * @param message                  The pre-formatted message string.
+         * @param persistentNotificationId The ID of the saved persistent notification.
+         * @return A map containing data for the SSE event.
+         */
+        public abstract Map<String, Object> buildSseData(Pqrs pqrs, User recipient, String message, String persistentNotificationId);
+    }
+
+    public void sendPqrsNotification(Pqrs pqrs, PqrsNotificationType type, User recipientUser, Object... messageArgs) {
+        if (recipientUser == null) {
+            LOG.warn("Recipient user is null for PQRS ID: {}. Notification not sent.", pqrs.getId());
+            return;
+        }
+
+        String message = type.getFormattedMessage(pqrs, messageArgs);
+
+        Notificacion persistentNotification = new Notificacion();
+        persistentNotification.setFecha(Instant.now());
+        persistentNotification.setLeido(false);
+        persistentNotification.setMensaje(message);
+        persistentNotification.setRecipient(recipientUser);
+        persistentNotification.setTipo(type.getEventKey());
+        notificacionRepository.save(persistentNotification);
+
+        Map<String, Object> sseData = type.buildSseData(pqrs, recipientUser, message, persistentNotification.getId().toString());
+
+        sseNotificationService.sendNotificationToUser(recipientUser.getLogin(), type.getEventKey(), sseData);
+    }
+
+    public void sendPqrsNotification(Pqrs pqrs, PqrsNotificationType type, String recipientAuthority, Object... messageArgs) {
+        User recipient = userRepository.findByAuthoritiesName(recipientAuthority);
+        if (recipient == null) {
+            LOG.warn(
+                "No user found with authority {} to send notification for PQRS ID: {}. Notification not sent.",
+                recipientAuthority,
+                pqrs.getId()
+            );
+            return;
+        }
+        sendPqrsNotification(pqrs, type, recipient, messageArgs);
+    }
+}

--- a/src/main/java/co/edu/itp/svu/service/notification/SseNotificationService.java
+++ b/src/main/java/co/edu/itp/svu/service/notification/SseNotificationService.java
@@ -1,4 +1,4 @@
-package co.edu.itp.svu.service;
+package co.edu.itp.svu.service.notification;
 
 import java.io.IOException;
 import java.util.Map;

--- a/src/main/java/co/edu/itp/svu/web/rest/SseNotificationResource.java
+++ b/src/main/java/co/edu/itp/svu/web/rest/SseNotificationResource.java
@@ -1,12 +1,11 @@
 package co.edu.itp.svu.web.rest;
 
 import co.edu.itp.svu.security.SecurityUtils;
-import co.edu.itp.svu.service.SseNotificationService;
+import co.edu.itp.svu.service.notification.SseNotificationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/webapp/app/app.component.ts
+++ b/src/main/webapp/app/app.component.ts
@@ -9,7 +9,7 @@ import { useDateFormat } from '@/shared/composables';
 import '@/shared/config/dayjs';
 
 import { useAccountStore } from './shared/config/store/account-store';
-import { useNotificationStore } from './shared/config/store/notification-store';
+import { useNotificationStore, type NotificationItem } from './shared/config/store/notification-store';
 import useDataUtils from './shared/data/data-utils.service';
 
 import sseNotificationService from './services/sse-notification.service';
@@ -61,17 +61,7 @@ export default defineComponent({
         const latestItem = newSseItems.find(newItem => !oldSseItems.some(oldItem => oldItem.id === newItem.id));
 
         if (latestItem && latestItem.isSse) {
-          alertService.showInfo(
-            t('sse-notification.message', {
-              pqrsTitle: latestItem.pqrsTitle,
-              pqrsId: latestItem.pqrsId,
-              pqrsDueDate: dateFormat.formatDateLong(latestItem.pqrsResponseDueDate),
-            }),
-            {
-              href: `/pqrs/${latestItem.pqrsId}/view`,
-              title: `${latestItem.pqrsTitle}`,
-            },
-          );
+          getAlertByNotificationType(latestItem);
         }
       },
       { deep: true },
@@ -84,6 +74,45 @@ export default defineComponent({
     onBeforeUnmount(() => {
       sseNotificationService.cleanup();
     });
+
+    const getAlertByNotificationType = (notification: NotificationItem) => {
+      switch (notification.type) {
+        case 'PQRS_DUE_DATE_REMINDER':
+          return alertService.showInfo(
+            t('sse-notification.due-date-message', {
+              pqrsTitle: notification.pqrsTitle,
+              pqrsId: notification.pqrsId,
+              pqrsDueDate: dateFormat.formatDateLong(notification.pqrsResponseDueDate),
+            }),
+            {
+              href: `/pqrs/${notification.pqrsId}/view`,
+              title: `${notification.pqrsTitle}`,
+            },
+          );
+        case 'PQRS_STATE_UPDATE':
+          return alertService.showInfo(
+            t('sse-notification.state-update-message', {
+              pqrsTitle: notification.pqrsTitle,
+              pqrsId: notification.pqrsId,
+            }),
+            {
+              href: `/pqrs/${notification.pqrsId}/view`,
+              title: `${notification.pqrsTitle}`,
+            },
+          );
+        case 'PQRS_CREATED':
+          return alertService.showInfo(
+            t('sse-notification.created-message', {
+              pqrsTitle: notification.pqrsTitle,
+              pqrsId: notification.pqrsId,
+            }),
+            {
+              href: `/pqrs/${notification.pqrsId}/view`,
+              title: `${notification.pqrsTitle}`,
+            },
+          );
+      }
+    };
 
     provide('alertService', useAlertService());
     return {

--- a/src/main/webapp/app/constants.ts
+++ b/src/main/webapp/app/constants.ts
@@ -12,4 +12,6 @@ export enum PqrsStatus {
 
 export enum NotificationType {
   PQRS_DUE_DATE_REMINDER = 'sse-notification.pqrs-due-date-reminder',
+  PQRS_STATE_UPDATE = 'sse-notification.pqrs-state-update',
+  PQRS_CREATED = 'sse-notification.pqrs-created',
 }

--- a/src/main/webapp/app/core/jhi-navbar/notification-bell.component.ts
+++ b/src/main/webapp/app/core/jhi-navbar/notification-bell.component.ts
@@ -48,12 +48,32 @@ export default defineComponent({
     };
 
     const truncateMessage = (notification: NotificationItem, length: number): string => {
-      const messageLang = t$('sse-notification.message', {
-        pqrsTitle: notification.pqrsTitle,
-        pqrsId: notification.pqrsId,
-        pqrsDueDate: dateFormat.formatDateLong(notification.pqrsResponseDueDate),
-      });
+      const messageLang = getTranslationByNotificationType(notification);
+
       return messageLang.length > length ? messageLang.substring(0, length) + '...' : messageLang;
+    };
+
+    const getTranslationByNotificationType = (notification: NotificationItem) => {
+      switch (notification.type) {
+        case 'PQRS_DUE_DATE_REMINDER':
+          return t$('sse-notification.due-date-message', {
+            pqrsTitle: notification.pqrsTitle,
+            pqrsId: notification.pqrsId,
+            pqrsDueDate: dateFormat.formatDateLong(notification.pqrsResponseDueDate),
+          });
+        case 'PQRS_STATE_UPDATE':
+          return t$('sse-notification.state-update-message', {
+            pqrsTitle: notification.pqrsTitle,
+            pqrsId: notification.pqrsId,
+          });
+        case 'PQRS_CREATED':
+          return t$('sse-notification.created-message', {
+            pqrsTitle: notification.pqrsTitle,
+            pqrsId: notification.pqrsId,
+          });
+      }
+
+      return t$('sse-notification.error');
     };
 
     return {

--- a/src/main/webapp/app/router/entities.ts
+++ b/src/main/webapp/app/router/entities.ts
@@ -60,13 +60,13 @@ export default {
       path: 'pqrs',
       name: 'Pqrs',
       component: Pqrs,
-      meta: { authorities: [Authority.FUNCTIONARY, Authority.ADMIN] },
+      meta: { authorities: [Authority.FUNCTIONARY, Authority.ADMIN, Authority.FRONT_DESK_CS] },
     },
     {
       path: 'pqrs/new',
       name: 'PqrsCreate',
       component: PqrsUpdate,
-      meta: { authorities: [Authority.USER] },
+      meta: { authorities: [Authority.USER, Authority.FRONT_DESK_CS, Authority.ADMIN] },
     },
     {
       path: 'pqrs/:pqrsId/edit',
@@ -78,7 +78,7 @@ export default {
       path: 'pqrs/:pqrsId/view',
       name: 'PqrsView',
       component: PqrsDetails,
-      meta: { authorities: [Authority.FUNCTIONARY, Authority.ADMIN] },
+      meta: { authorities: [Authority.ADMIN, Authority.FUNCTIONARY, Authority.FRONT_DESK_CS] },
     },
     {
       path: 'respuesta',

--- a/src/main/webapp/app/shared/security/authority.ts
+++ b/src/main/webapp/app/shared/security/authority.ts
@@ -2,4 +2,5 @@ export enum Authority {
   ADMIN = 'ROLE_ADMIN',
   USER = 'ROLE_USER',
   FUNCTIONARY = 'ROLE_FUNCTIONARY',
+  FRONT_DESK_CS = 'ROLE_FRONT_DESK_CS',
 }

--- a/src/main/webapp/i18n/en/sse-notification.json
+++ b/src/main/webapp/i18n/en/sse-notification.json
@@ -1,10 +1,15 @@
 {
   "sse-notification": {
     "non-type": "Type: N/A",
-    "message": "PQRS '{pqrsTitle}' (ID: {pqrsId}) is due on '{pqrsDueDate}'.",
+    "due-date-message": "PQRS '{pqrsTitle}' (ID: {pqrsId}) is due on '{pqrsDueDate}'.",
+    "state-update-message": "PQRS '{pqrsTitle}' (ID: {pqrsId}) status has been updated to RESOLVED.",
+    "created-message": "PQRS '{pqrsTitle}' (ID: {pqrsId}) was CREATED.",
     "pqrs-due-date-reminder": "PQRS due date reminder",
+    "pqrs-state-update": "PQRS status update",
+    "pqrs-created": "New PQRS created",
     "mark-all-as-read": "Mark all as read",
     "view-all-notifications": "View all notifications",
-    "no-new-notifications": "No new notifications"
+    "no-new-notifications": "No new notifications",
+    "error": "Unable to display the notification message"
   }
 }

--- a/src/main/webapp/i18n/es/sse-notification.json
+++ b/src/main/webapp/i18n/es/sse-notification.json
@@ -1,10 +1,15 @@
 {
   "sse-notification": {
     "non-type": "Tipo: N/A",
-    "message": "La PQRS '{pqrsTitle}' (ID: {pqrsId}) vence el '{pqrsDueDate}'.",
+    "due-date-message": "La PQRS '{pqrsTitle}' (ID: {pqrsId}) vence el '{pqrsDueDate}'.",
+    "state-update-message": "El estado del PQRS '{pqrsTitle}' (ID: {pqrsId}) se ha actualizado a RESUELTA",
+    "created-message": "La PQRS '{pqrsTitle}' (ID: {pqrsId}) fue CREADA.",
     "pqrs-due-date-reminder": "Recordatorio: Vencimiento del plazo para PQRS",
+    "pqrs-state-update": "Actualización del estado de la PQRS",
+    "pqrs-created": "Nueva PQRS creada",
     "mark-all-as-read": "Marcar todo como leído",
     "view-all-notifications": "Ver todas las notificaciones",
-    "no-new-notifications": "No hay notificaciones nuevas"
+    "no-new-notifications": "No hay notificaciones nuevas",
+    "error": "No se puede mostrar el mensaje de la notificación"
   }
 }


### PR DESCRIPTION
### Description
In this PR was added the functionality to handle SSE notifications when the user **creates** or **update** a pqrs, in the case of update only when is resolved.

When one of these actions happens, the **frontdesk** user should see an alert if he has the application open, otherwise he should see it in the menu or notifications page.

### Fixes #50 

### Screenshots or videos

![image](https://github.com/user-attachments/assets/acee0ba9-3015-43d3-9f52-3529faaf0752)
