### PR TITLE
Add the necessary logic to manage Satisfaction Survey in the API

### DIFF
--- a/src/main/java/co/edu/itp/svu/domain/Pqrs.java
+++ b/src/main/java/co/edu/itp/svu/domain/Pqrs.java
@@ -75,11 +75,24 @@ public class Pqrs implements Serializable {
     @JsonIgnoreProperties(value = { "notificacions" }, allowSetters = true)
     private Oficina oficinaResponder;
 
+    @DBRef
+    @Field("satisfaction_survey")
+    @JsonIgnoreProperties(value = { "pqrs" }, allowSetters = true)
+    private SatisfactionSurvey satisfactionSurvey;
+
     @Transient
     private transient Set<ArchivoAdjunto> _transientAttachments;
 
     @Transient
     private transient Set<Respuesta> _transientResponses;
+
+    public SatisfactionSurvey getSatisfactionSurvey() {
+        return satisfactionSurvey;
+    }
+
+    public void setSatisfactionSurvey(SatisfactionSurvey satisfactionSurvey) {
+        this.satisfactionSurvey = satisfactionSurvey;
+    }
 
     public Set<ArchivoAdjunto> get_transientAttachments() {
         return _transientAttachments;

--- a/src/main/java/co/edu/itp/svu/domain/SatisfactionSurvey.java
+++ b/src/main/java/co/edu/itp/svu/domain/SatisfactionSurvey.java
@@ -1,0 +1,80 @@
+package co.edu.itp.svu.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.io.Serializable;
+import java.time.Instant;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Document(collection = "satisfaction_survey")
+public class SatisfactionSurvey implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    private String id;
+
+    @NotNull
+    @Min(value = 1)
+    @Max(value = 5)
+    @Field("rating")
+    private Integer rating; // 1: Very Unsatisfied, 5: Very Satisfied
+
+    @Field("comment")
+    private String comment;
+
+    @Field("submission_date")
+    private Instant submissionDate;
+
+    @DBRef
+    @Indexed(unique = true)
+    @JsonIgnore
+    @Field("pqrs")
+    private Pqrs pqrs;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Integer getRating() {
+        return rating;
+    }
+
+    public void setRating(Integer rating) {
+        this.rating = rating;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    public Instant getSubmissionDate() {
+        return submissionDate;
+    }
+
+    public void setSubmissionDate(Instant submissionDate) {
+        this.submissionDate = submissionDate;
+    }
+
+    public Pqrs getPqrs() {
+        return pqrs;
+    }
+
+    public void setPqrs(Pqrs pqrs) {
+        this.pqrs = pqrs;
+    }
+}

--- a/src/main/java/co/edu/itp/svu/repository/SatisfactionSurveyRepository.java
+++ b/src/main/java/co/edu/itp/svu/repository/SatisfactionSurveyRepository.java
@@ -1,0 +1,11 @@
+package co.edu.itp.svu.repository;
+
+import co.edu.itp.svu.domain.SatisfactionSurvey;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Spring Data MongoDB repository for the SatisfactionSurvey entity.
+ */
+@Repository
+public interface SatisfactionSurveyRepository extends MongoRepository<SatisfactionSurvey, String> {}

--- a/src/main/java/co/edu/itp/svu/service/dto/CreateSatisfactionSurveyDTO.java
+++ b/src/main/java/co/edu/itp/svu/service/dto/CreateSatisfactionSurveyDTO.java
@@ -1,0 +1,32 @@
+package co.edu.itp.svu.service.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.io.Serializable;
+
+public class CreateSatisfactionSurveyDTO implements Serializable {
+
+    @NotNull
+    @Min(value = 1)
+    @Max(value = 5)
+    private Integer rating;
+
+    private String comment;
+
+    public Integer getRating() {
+        return rating;
+    }
+
+    public void setRating(Integer rating) {
+        this.rating = rating;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+}

--- a/src/main/java/co/edu/itp/svu/service/dto/PqrsDTO.java
+++ b/src/main/java/co/edu/itp/svu/service/dto/PqrsDTO.java
@@ -46,6 +46,16 @@ public class PqrsDTO implements Serializable {
 
     private Set<ResponseDTO> _transientResponses = new HashSet<>();
 
+    private SatisfactionSurveyDTO satisfactionSurvey;
+
+    public SatisfactionSurveyDTO getSatisfactionSurvey() {
+        return satisfactionSurvey;
+    }
+
+    public void setSatisfactionSurvey(SatisfactionSurveyDTO satisfactionSurvey) {
+        this.satisfactionSurvey = satisfactionSurvey;
+    }
+
     public Set<ArchivoAdjuntoDTO> getArchivosAdjuntosDTO() {
         return archivosAdjuntosDTO;
     }

--- a/src/main/java/co/edu/itp/svu/service/dto/SatisfactionSurveyDTO.java
+++ b/src/main/java/co/edu/itp/svu/service/dto/SatisfactionSurveyDTO.java
@@ -1,0 +1,66 @@
+package co.edu.itp.svu.service.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.io.Serializable;
+import java.time.Instant;
+
+/**
+ * A DTO for the {@link co.edu.itp.svu.domain.SatisfactionSurvey} entity.
+ */
+public class SatisfactionSurveyDTO implements Serializable {
+
+    private String id;
+
+    @NotNull
+    @Min(value = 1)
+    @Max(value = 5)
+    private Integer rating;
+
+    private String comment;
+
+    private Instant submissionDate;
+
+    private PqrsDTO pqrs;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Integer getRating() {
+        return rating;
+    }
+
+    public void setRating(Integer rating) {
+        this.rating = rating;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    public Instant getSubmissionDate() {
+        return submissionDate;
+    }
+
+    public void setSubmissionDate(Instant submissionDate) {
+        this.submissionDate = submissionDate;
+    }
+
+    public PqrsDTO getPqrs() {
+        return pqrs;
+    }
+
+    public void setPqrs(PqrsDTO pqrs) {
+        this.pqrs = pqrs;
+    }
+}

--- a/src/main/java/co/edu/itp/svu/service/mapper/PqrsMapper.java
+++ b/src/main/java/co/edu/itp/svu/service/mapper/PqrsMapper.java
@@ -8,12 +8,14 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.mapstruct.*;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = { SatisfactionSurveyMapper.class })
 public interface PqrsMapper extends EntityMapper<PqrsDTO, Pqrs> {
     @Mapping(target = "archivosAdjuntosDTO", source = "archivosAdjuntos")
+    @Mapping(source = "satisfactionSurvey.id", target = "satisfactionSurvey.id")
     PqrsDTO toDto(Pqrs pqrs);
 
     @Mapping(target = "archivosAdjuntos", source = "archivosAdjuntosDTO")
+    @Mapping(source = "satisfactionSurvey.id", target = "satisfactionSurvey")
     Pqrs toEntity(PqrsDTO pqrsDTO);
 
     default Set<ArchivoAdjuntoDTO> mapArchivosAdjuntosToDTOs(Set<ArchivoAdjunto> archivosAdjuntos) {

--- a/src/main/java/co/edu/itp/svu/service/mapper/SatisfactionSurveyMapper.java
+++ b/src/main/java/co/edu/itp/svu/service/mapper/SatisfactionSurveyMapper.java
@@ -1,0 +1,52 @@
+package co.edu.itp.svu.service.mapper;
+
+import co.edu.itp.svu.domain.Pqrs;
+import co.edu.itp.svu.domain.SatisfactionSurvey;
+import co.edu.itp.svu.repository.SatisfactionSurveyRepository;
+import co.edu.itp.svu.service.dto.PqrsDTO;
+import co.edu.itp.svu.service.dto.SatisfactionSurveyDTO;
+import org.mapstruct.*;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Mapper for the entity {@link SatisfactionSurvey} and its DTO {@link SatisfactionSurveyDTO}.
+ */
+@Mapper(componentModel = "spring")
+public abstract class SatisfactionSurveyMapper implements EntityMapper<SatisfactionSurveyDTO, SatisfactionSurvey> {
+
+    @Autowired
+    protected SatisfactionSurveyRepository satisfactionSurveyRepository;
+
+    @Override
+    @Mapping(target = "pqrs", ignore = true)
+    public abstract SatisfactionSurveyDTO toDto(SatisfactionSurvey satisfactionSurvey);
+
+    @AfterMapping
+    protected void populatePqrsDto(SatisfactionSurvey satisfactionSurvey, @MappingTarget SatisfactionSurveyDTO satisfactionSurveyDTO) {
+        if (satisfactionSurvey.getPqrs() != null) {
+            PqrsDTO pqrsDTO = new PqrsDTO();
+            pqrsDTO.setId(satisfactionSurvey.getPqrs().getId());
+            satisfactionSurveyDTO.setPqrs(pqrsDTO);
+        }
+    }
+
+    @Override
+    @Mapping(target = "pqrs", ignore = true)
+    public abstract SatisfactionSurvey toEntity(SatisfactionSurveyDTO satisfactionSurveyDTO);
+
+    @AfterMapping
+    protected void linkPqrs(SatisfactionSurveyDTO satisfactionSurveyDTO, @MappingTarget SatisfactionSurvey satisfactionSurvey) {
+        if (satisfactionSurveyDTO.getPqrs() != null && satisfactionSurveyDTO.getPqrs().getId() != null) {
+            Pqrs pqrs = new Pqrs();
+            pqrs.setId(satisfactionSurveyDTO.getPqrs().getId());
+            satisfactionSurvey.setPqrs(pqrs);
+        }
+    }
+
+    public SatisfactionSurvey fromId(String id) {
+        if (id == null) {
+            return null;
+        }
+        return satisfactionSurveyRepository.findById(id).orElse(null);
+    }
+}

--- a/src/main/webapp/i18n/en/pqrs.json
+++ b/src/main/webapp/i18n/en/pqrs.json
@@ -1,5 +1,8 @@
 {
   "ventanillaUnicaApp": {
+    "survey": {
+      "submitted": "The Satisfaction Survey has been submitted"
+    },
     "pqrs": {
       "action": {
         "title": "Actions",

--- a/src/main/webapp/i18n/es/pqrs.json
+++ b/src/main/webapp/i18n/es/pqrs.json
@@ -1,5 +1,8 @@
 {
   "ventanillaUnicaApp": {
+    "survey": {
+      "submitted": "La encuesta de satisfacción ha sido enviada"
+    },
     "pqrs": {
       "action": {
         "title": "Acciones",


### PR DESCRIPTION
### Description
In this PR was added the endpoint to create a satisfaction survey in the spring-boot API

### Fixes #113 

### Screenshots or videos

<img width="1881" height="824" alt="image" src="https://github.com/user-attachments/assets/170d21d9-88b8-40b6-b835-b6f3fc809385" />

<img width="1424" height="789" alt="image" src="https://github.com/user-attachments/assets/d0f3fcf6-f877-46f2-adfd-2e7b503241d7" />

