### PR TITLE
Hidden the bottom to create a new attached file

### DIFF
--- a/src/main/webapp/app/entities/archivo-adjunto/archivo-adjunto.vue
+++ b/src/main/webapp/app/entities/archivo-adjunto/archivo-adjunto.vue
@@ -12,7 +12,7 @@
             @click="navigate"
             id="jh-create-entity"
             data-cy="entityCreateButton"
-            class="btn btn-primary jh-create-entity create-archivo-adjunto"
+            class="d-none btn btn-primary jh-create-entity create-archivo-adjunto"
           >
             <font-awesome-icon icon="plus"></font-awesome-icon>
             <span v-text="t$('ventanillaUnicaApp.archivoAdjunto.home.createLabel')"></span>


### PR DESCRIPTION
### Description
To simplify the fix,  i just hid the button for creating attachments

### Fixes #125 

### Screenshots or videos
<img width="1901" height="939" alt="image" src="https://github.com/user-attachments/assets/d5ecd80b-4abe-475e-95c0-e79360ca27de" />
