### PR TITLE
Add the list of attachments files to the response detail view

### DIFF
--- a/src/main/webapp/app/entities/respuesta/respuesta-details.component.ts
+++ b/src/main/webapp/app/entities/respuesta/respuesta-details.component.ts
@@ -7,10 +7,14 @@ import useDataUtils from '@/shared/data/data-utils.service';
 import { useDateFormat } from '@/shared/composables';
 import { type IRespuesta } from '@/shared/model/respuesta.model';
 import { useAlertService } from '@/shared/alert/alert.service';
+import AttachmentList from '@/entities/archivo-adjunto/attachment-list.vue';
 
 export default defineComponent({
   compatConfig: { MODE: 3 },
   name: 'RespuestaDetails',
+  components: {
+    'attachment-list': AttachmentList,
+  },
   setup() {
     const dateFormat = useDateFormat();
     const respuestaService = inject('respuestaService', () => new RespuestaService());

--- a/src/main/webapp/app/entities/respuesta/respuesta-details.vue
+++ b/src/main/webapp/app/entities/respuesta/respuesta-details.vue
@@ -7,6 +7,14 @@
         </h2>
         <dl class="row jh-entity-details">
           <dt>
+            <span v-text="t$('ventanillaUnicaApp.respuesta.pqr')"></span>
+          </dt>
+          <dd>
+            <div v-if="respuesta.pqrs">
+              <router-link :to="{ name: 'PqrsView', params: { pqrsId: respuesta.pqrs.id } }">{{ respuesta.pqrs.id }}</router-link>
+            </div>
+          </dd>
+          <dt>
             <span v-text="t$('ventanillaUnicaApp.respuesta.contenido')"></span>
           </dt>
           <dd>
@@ -18,15 +26,8 @@
           <dd>
             <span v-if="respuesta.fechaRespuesta">{{ formatDateLong(respuesta.fechaRespuesta) }}</span>
           </dd>
-          <dt>
-            <span v-text="t$('ventanillaUnicaApp.respuesta.pqr')"></span>
-          </dt>
-          <dd>
-            <div v-if="respuesta.pqrs">
-              <router-link :to="{ name: 'PqrsView', params: { pqrsId: respuesta.pqrs.id } }">{{ respuesta.pqrs.id }}</router-link>
-            </div>
-          </dd>
         </dl>
+        <attachment-list :attachments="respuesta._transientAttachments"></attachment-list>
         <button type="submit" @click.prevent="previousState()" class="btn btn-info" data-cy="entityDetailsBackButton">
           <font-awesome-icon icon="arrow-left"></font-awesome-icon>&nbsp;<span v-text="t$('entity.action.back')"></span>
         </button>


### PR DESCRIPTION
### Description
Add the `attchment-list` component to the `respuesta-details` view to display the files belonging to that response

### Fixes #126 

### Screenshots or videos
<img width="1900" height="881" alt="image" src="https://github.com/user-attachments/assets/38150db4-f3fd-4a98-b1c0-0e4df01bbd2e" />
